### PR TITLE
FEAT/ 토큰 재발급

### DIFF
--- a/src/main/java/com/example/speechmate_backend/config/redis/RedisUtil.java
+++ b/src/main/java/com/example/speechmate_backend/config/redis/RedisUtil.java
@@ -5,16 +5,35 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Component
 public class RedisUtil {
 
     private final StringRedisTemplate redisTemplate;
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
 
 
     public void storeRefreshToken(String usernum, String refreshToken, long ttlHour) {
-        redisTemplate.opsForValue().set("user" + usernum, refreshToken, Duration.ofHours(ttlHour));
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_PREFIX + usernum, refreshToken, Duration.ofHours(ttlHour));
     }
 
+    public boolean isBlacklisted(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token));
+    }
+
+    public void addToBlacklist(String token, long ttl) {
+        redisTemplate.opsForValue().set(
+                BLACKLIST_PREFIX + token,
+                "true",
+                ttl,
+                TimeUnit.SECONDS
+        );
+    }
+
+    public String getRefreshToken(String userId) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+    }
 }

--- a/src/main/java/com/example/speechmate_backend/user/controller/AuthController.java
+++ b/src/main/java/com/example/speechmate_backend/user/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.example.speechmate_backend.user.controller;
 
 import com.example.speechmate_backend.common.ApiResponse;
 import com.example.speechmate_backend.common.exception.InvalidOauthProviderException;
+import com.example.speechmate_backend.user.controller.dto.TokenReissueRequest;
+import com.example.speechmate_backend.user.controller.dto.TokenReissueResponse;
 import com.example.speechmate_backend.user.domain.OauthInfo;
 import com.example.speechmate_backend.oauth.KakaoProperties;
 import com.example.speechmate_backend.oauth.dto.AfterOauthSignupDto;
@@ -12,6 +14,7 @@ import com.example.speechmate_backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -80,6 +83,13 @@ public class AuthController {
 
         String idToken = (String) response.getBody().get("id_token");
         return ResponseEntity.ok(idToken);
+    }
+
+    @Operation(summary = "refresh토큰 재발급", description = "액세스 토큰, 리프레쉬 토큰이 재발급되고 원래 리프레쉬 토큰은 블랙리스트에 추가합니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<TokenReissueResponse>> reissueAccessToken(@Valid @RequestBody TokenReissueRequest request) {
+        TokenReissueResponse response = userService.reissueToken(request.refreshToken());
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
 

--- a/src/main/java/com/example/speechmate_backend/user/controller/dto/TokenReissueRequest.java
+++ b/src/main/java/com/example/speechmate_backend/user/controller/dto/TokenReissueRequest.java
@@ -1,0 +1,9 @@
+package com.example.speechmate_backend.user.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenReissueRequest(
+        @NotBlank(message = "refresh token is required")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/speechmate_backend/user/controller/dto/TokenReissueResponse.java
+++ b/src/main/java/com/example/speechmate_backend/user/controller/dto/TokenReissueResponse.java
@@ -1,0 +1,9 @@
+package com.example.speechmate_backend.user.controller.dto;
+
+public record TokenReissueResponse(
+        String access,
+        String accessExpiredAt,
+        String refresh,
+        String refreshExpiredAt
+) {
+}

--- a/src/main/java/com/example/speechmate_backend/user/service/UserService.java
+++ b/src/main/java/com/example/speechmate_backend/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.speechmate_backend.user.service;
 import com.example.speechmate_backend.common.exception.UserAlreadyExistException;
 import com.example.speechmate_backend.config.redis.RedisUtil;
 import com.example.speechmate_backend.config.security.JwtUtil;
+import com.example.speechmate_backend.user.controller.dto.TokenReissueResponse;
 import com.example.speechmate_backend.user.domain.OauthInfo;
 import com.example.speechmate_backend.user.domain.User;
 import com.example.speechmate_backend.user.domain.UserSkill;
@@ -11,6 +12,7 @@ import com.example.speechmate_backend.user.repository.UserSkillRepository;
 import com.example.speechmate_backend.oauth.dto.AfterOauthSignupDto;
 import com.example.speechmate_backend.oauth.dto.OauthLoginResponse;
 import com.example.speechmate_backend.oauth.helper.KakaoOauthHelper;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -78,5 +80,9 @@ public class UserService {
 
         userSkillRepository.saveAll(userSkills);
         return generateLoginResponse(user, true);
+    }
+
+    public TokenReissueResponse reissueToken(@NotBlank(message = "refresh token is required") String refreshToken) {
+        return jwtUtil.reissueToken(refreshToken);
     }
 }


### PR DESCRIPTION
reissue 엔드포인트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to allow users to reissue (refresh) their access and refresh tokens using a valid refresh token.
  * Users now receive new access and refresh tokens, along with their respective expiration times, after a successful token reissue request.
  * Enhanced token security by blacklisting used refresh tokens, preventing their reuse.

* **Bug Fixes**
  * Improved validation and management of refresh tokens to ensure proper handling and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->