### PR TITLE
Feat/ #14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,24 @@ ext {
     set('springCloudVersion', "2023.0.3")
 }
 
+def queryDslVersion = "7.0" // 25년 7월 기준 가장 최신
+def querydslSrcDir  = layout.buildDirectory.dir("generated/querydsl").get().asFile // build/generated/querydsl
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslSrcDir))
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslSrcDir
+        }
+    }
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
 dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -80,6 +98,11 @@ dependencies {
 
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2' // Swagger
+
+    //Querydsl
+    implementation("io.github.openfeign.querydsl:querydsl-core:${queryDslVersion}")
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDslVersion")
+    annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
 
 }
 

--- a/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
+++ b/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode implements ErrorCodeIfs{
     SPEECH_CONTENT_ALREADY_EXIST("fail", HttpStatus.SC_CONFLICT, "stt로 변환된 content가 이미 존재."),
     SPEECH_CONTENT_NOT_EXIST("fail", HttpStatus.SC_CONFLICT, "stt로 변환된 content가 존재X"),
     SPEECH_ANALYSIS_RESULT_ALREADY_EXIST("fail", HttpStatus.SC_CONFLICT, "ai로 분석된 analysisREsult가 이미 존재."),
-    ;
+    SPEECH_FILE_KEY_DOES_NOT_EQUAL("fail", HttpStatus.SC_BAD_REQUEST, "파일 키가 저장된 것과 일치하지 않음");
 
 
     private final String status;

--- a/src/main/java/com/example/speechmate_backend/common/exception/SpeechFileKeyNotEqualException.java
+++ b/src/main/java/com/example/speechmate_backend/common/exception/SpeechFileKeyNotEqualException.java
@@ -1,0 +1,13 @@
+package com.example.speechmate_backend.common.exception;
+
+import com.example.speechmate_backend.common.error.ErrorCode;
+
+public class SpeechFileKeyNotEqualException extends SmateException {
+    public static final SmateException EXCEPTION = new SpeechFileKeyNotEqualException();
+
+
+
+    public SpeechFileKeyNotEqualException() {
+        super(ErrorCode.SPEECH_CONTENT_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/config/QueryDSLConfig.java
+++ b/src/main/java/com/example/speechmate_backend/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.example.speechmate_backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDSLConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
@@ -6,6 +6,7 @@ import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.controller.dto.VoiceKeyDto;
 import com.example.speechmate_backend.s3.controller.dto.VoiceRecordDto;
 import com.example.speechmate_backend.speech.controller.dto.SpeechIdDto;
+import com.example.speechmate_backend.speech.controller.dto.SpeechPagingResponseDto;
 import com.example.speechmate_backend.speech.controller.dto.SpeechResultDto;
 import com.example.speechmate_backend.speech.service.SpeechService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -86,6 +87,17 @@ public class SpeechController {
         return ResponseEntity.ok(ApiResponse.ok(speechId));
     }
 
+    @Operation(summary = "speech 조회", description = "클라이언트가 분석된 스피치들을 조회합니다.")
+    @GetMapping("/mine")
+    public ResponseEntity<ApiResponse<SpeechPagingResponseDto>> getSpeeches(
+            @RequestParam(required = false) Long lastSpeechId,
+            @RequestParam(defaultValue = "5") int limit,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId(); // 인증 유저 ID
+        SpeechPagingResponseDto response = speechService.getNextSpeeches(userId, lastSpeechId, limit);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 
 
    /* @PostMapping("/{speechId}/transcribeWithWhisper")

--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
@@ -30,15 +30,6 @@ public class SpeechController {
     private final SpeechService speechService;
     private final SpeechRestClient speechRestClient;
 
-    // 1. Speech 생성 + presigned URL 발급(gcs)
-    /*@Operation(summary = "gcs용 presigned url 발급(사용X)")
-    @PostMapping("/presignedWithGcs")
-    public ResponseEntity<ApiResponse<VoiceRecordDto>> createSpeechAndGetPresignedUrlGcs(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestParam MediaFileExtension fileExtension
-    ) {
-        return ResponseEntity.ok(ApiResponse.ok(speechService.createPresignedUrlGcp(customUserDetails.getUserId(), fileExtension)));
-    }*/
 
     @Operation(summary = "1. s3용 presigned url 발급", description ="요청 후에 나온 url에다가 put 메소드로 파일 업로드하면 됩니다")
     @PostMapping("/presignedWithS3")
@@ -77,6 +68,16 @@ public class SpeechController {
         return speechService.transcribeversion2(file, speechId);
     }
 
+    @Operation(summary = "2-1. whisper api s3에서 받아온것", description = "저장된 s3 파일로부터 stt로변환된 내용을 뽑아냅니다.(1을 먼저 선행하여 s3에 파일 저장후 요청해주세요")
+    @PostMapping(value = "/Whisperstt3/{speechId}")
+    public ResponseEntity<ApiResponse<String>> transcribes3(
+            @Parameter(description = "업로드할 음성 파일", required = true, content = @Content(mediaType = "multipart/form-data"))
+            @RequestParam("fileKey") String fileKey,
+            @PathVariable Long speechId) {
+        return speechService.transcribeversionFromS3(fileKey, speechId);
+    }
+
+
     @Operation(summary = "1-1. 업로드 완료 콜백", description = "클라이언트가 presigned url로 업로드 완료한 후 콜백 합니다.")
     @PostMapping("/s3-callback")
     public ResponseEntity<ApiResponse<SpeechIdDto>> callbackAfterUpload(
@@ -100,38 +101,6 @@ public class SpeechController {
     }
 
 
-   /* @PostMapping("/{speechId}/transcribeWithWhisper")
-    public ResponseEntity<ApiResponse<Long>> transcribeSpeechWithWhisper(
-            @PathVariable Long speechId
-    ) {
-        speechService.transcribeWithWhisper(speechId);
-        return ResponseEntity.ok(ApiResponse.ok(speechId));
-    }*/
-
-    // s3 presigned url로 파일 올린 후  안되서 임시로 만든 upload
-    /*@PostMapping("/upload/{speechId}")
-    public ResponseEntity<String> testUploadWhisper(
-            @PathVariable Long speechId,
-            @RequestPart("file") MultipartFile file
-
-    ) {
-        //String result = speechService.transcribeWithMultipartFile(file, speechId);
-        String result = speechService.callWhisperStt(file, speechId);
-
-        return ResponseEntity.ok(result);
-    }*/
-
-
-
-
-
-    /*@PostMapping("/{speechId}/transcribe")
-    public ResponseEntity<ApiResponse<Long>> transcribeSpeechWithGoogle(
-            @PathVariable Long speechId
-    ) {
-        speechService.transcribeWithGoogle(speechId);
-        return ResponseEntity.ok(ApiResponse.ok(speechId));
-    }*/
 
 
 

--- a/src/main/java/com/example/speechmate_backend/speech/controller/dto/CursorDto.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/dto/CursorDto.java
@@ -1,0 +1,9 @@
+package com.example.speechmate_backend.speech.controller.dto;
+
+import java.time.LocalDateTime;
+
+public record CursorDto(
+        LocalDateTime dateTime,
+        Long id
+) {}
+

--- a/src/main/java/com/example/speechmate_backend/speech/controller/dto/SpeechAnalysisResponseDto.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/dto/SpeechAnalysisResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.speechmate_backend.speech.controller.dto;
+
+import java.time.LocalDateTime;
+
+public record SpeechAnalysisResponseDto(
+        Long speechId,
+        LocalDateTime createdAt,
+        String fileUrl,
+        String content,
+        String summary,
+        String keywords,
+        String improvementPoints,
+        int logicalCoherenceScore,
+        String feedback,
+        String scoreExplanation,
+        String expectedQuestions
+
+) {
+}

--- a/src/main/java/com/example/speechmate_backend/speech/controller/dto/SpeechPagingResponseDto.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/dto/SpeechPagingResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.speechmate_backend.speech.controller.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record SpeechPagingResponseDto(
+        List<SpeechAnalysisResponseDto> speeches,
+        boolean hasNext,
+        CursorDto cursordto
+) {
+}
+

--- a/src/main/java/com/example/speechmate_backend/speech/repository/SpeechCustomRepository.java
+++ b/src/main/java/com/example/speechmate_backend/speech/repository/SpeechCustomRepository.java
@@ -1,0 +1,11 @@
+package com.example.speechmate_backend.speech.repository;
+
+import com.example.speechmate_backend.speech.controller.dto.SpeechAnalysisResponseDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SpeechCustomRepository {
+    List<SpeechAnalysisResponseDto> findNextSpeeches(Long userId, Long lastSpeechId, int limit);
+}

--- a/src/main/java/com/example/speechmate_backend/speech/repository/SpeechCustomRepositoryImpl.java
+++ b/src/main/java/com/example/speechmate_backend/speech/repository/SpeechCustomRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.example.speechmate_backend.speech.repository;
+
+import com.example.speechmate_backend.speech.controller.dto.SpeechAnalysisResponseDto;
+import com.example.speechmate_backend.speech.domain.QAnalysisResult;
+import com.example.speechmate_backend.speech.domain.QSpeech;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SpeechCustomRepositoryImpl implements SpeechCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QSpeech speech = QSpeech.speech;
+    QAnalysisResult analysisResult = QAnalysisResult.analysisResult;
+
+    @Override
+    public List<SpeechAnalysisResponseDto> findNextSpeeches(Long userId, Long lastSpeechId, int limit) {
+        return jpaQueryFactory
+                .select(Projections.constructor(SpeechAnalysisResponseDto.class,
+                        speech.id,
+                        speech.createdAt,
+                        speech.FileUrl,
+                        speech.content,
+                        analysisResult.summary,
+                        analysisResult.keywords,
+                        analysisResult.improvementPoints,
+                        analysisResult.logicalCoherenceScore,
+                        analysisResult.feedback,
+                        analysisResult.scoreExplanation,
+                        analysisResult.expectedQuestions
+                ))
+                .from(speech)
+                .join(speech.analysisResult)
+                .where(
+                        speech.user.id.eq(userId),
+                        speech.id.gt(lastSpeechId)
+                )
+                .orderBy(speech.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -1,10 +1,7 @@
 package com.example.speechmate_backend.speech.service;
 
 import com.example.speechmate_backend.common.ApiResponse;
-import com.example.speechmate_backend.common.exception.SpeechContentAlreadyExistException;
-import com.example.speechmate_backend.common.exception.SpeechContentNotExistException;
-import com.example.speechmate_backend.common.exception.SpeechNotFoundException;
-import com.example.speechmate_backend.common.exception.UserNotFoundException;
+import com.example.speechmate_backend.common.exception.*;
 import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.controller.dto.VoiceKeyDto;
 import com.example.speechmate_backend.s3.controller.dto.VoiceRecordDto;
@@ -28,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 
@@ -171,6 +169,26 @@ public class SpeechService {
         }
     }
 
+    public ResponseEntity<ApiResponse<String>> transcribeversionFromS3(String fileKey, Long speechId) {
+        try {
+            Speech speech = speechRepository.findById(speechId)
+                    .orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
+            if(speech.getContent() != null && !speech.getContent().isEmpty()) {
+                throw SpeechContentAlreadyExistException.EXCEPTION;
+            }
+            if(!Objects.equals(speech.getFileUrl(), fileKey)) {
+                throw SpeechFileKeyNotEqualException.EXCEPTION;
+            }
+            String content = speechRestClient.transcribeversionFromS3(fileKey);
+            speech.setContent(content);
+            speechRepository.save(speech);
+
+            return ResponseEntity.ok(ApiResponse.ok(content));
+        } catch (Exception e) {
+            throw new RuntimeException("Whisper 변환 실패: " + e.getMessage(), e);
+        }
+
+    }
 
 
 

--- a/src/test/java/com/example/speechmate_backend/SpeechMateBackendApplicationTests.java
+++ b/src/test/java/com/example/speechmate_backend/SpeechMateBackendApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class SpeechMateBackendApplicationTests {
 
-    @Test
+    /*@Test
     void contextLoads() {
-    }
+    }*/
 
 }


### PR DESCRIPTION
- 분석된 스피치 조회
- 업로드 완료된것만 filekey저장
- multipart로 whisper요청 -> s3에 저장되어있는 파일로 whisper 요청

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to transcribe speech from an existing S3 file using a file key.
  * Introduced paginated retrieval of analyzed speeches for authenticated users, with support for cursor-based pagination.
  * Implemented backend support for QueryDSL to enable advanced querying capabilities.

* **Bug Fixes**
  * Improved error handling for mismatched speech file keys with new error codes and exception types.

* **Chores**
  * Cleaned up unused and commented-out code in controllers and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->