### PR TITLE
REFACTOR/ 피드 조회시 캐싱

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
+++ b/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode implements ErrorCodeIfs{
     SPEECH_FILE_KEY_DOES_NOT_EQUAL("fail", HttpStatus.SC_BAD_REQUEST, "파일 키가 저장된 것과 일치하지 않음"),
     SPEECH_FILE_KEY_NOT_FOUND("fail", HttpStatus.SC_NOT_FOUND, "파일키가 없음"),
     WHISPER_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "stt를 받아오는 whisper과정에서 오류 발생"),
-    USER_NOT_MATCH("fail", HttpStatus.SC_FORBIDDEN, "현재 로그인 한 유저가 일치하지 않습니다.");
+    USER_NOT_MATCH("fail", HttpStatus.SC_FORBIDDEN, "현재 로그인 한 유저가 일치하지 않습니다."),
+    FILE_TOO_LARGE("fail", HttpStatus.SC_BAD_REQUEST, "파일 크기가 25MB가 넘어갑니다. 작은 파일을 업로드해주세요"),
+    FFMPEG_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "파일 변환 중 오류 발생(ffmpeg)");
 
 
     private final String status;

--- a/src/main/java/com/example/speechmate_backend/common/exception/FFmpegException.java
+++ b/src/main/java/com/example/speechmate_backend/common/exception/FFmpegException.java
@@ -1,0 +1,11 @@
+package com.example.speechmate_backend.common.exception;
+
+import com.example.speechmate_backend.common.error.ErrorCode;
+
+public class FFmpegException extends SmateException {
+    public static final SmateException EXECPTION = new FFmpegException();
+
+    public FFmpegException() {
+        super(ErrorCode.FFMPEG_EXCEPTION);
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/common/exception/FileTooLargeException.java
+++ b/src/main/java/com/example/speechmate_backend/common/exception/FileTooLargeException.java
@@ -1,0 +1,12 @@
+package com.example.speechmate_backend.common.exception;
+
+import com.example.speechmate_backend.common.error.ErrorCode;
+
+public class FileTooLargeException extends SmateException {
+    public static final SmateException EXCEPTION = new FileTooLargeException();
+
+    public FileTooLargeException() {
+        super(ErrorCode.FILE_TOO_LARGE);
+    }
+
+}

--- a/src/main/java/com/example/speechmate_backend/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/speechmate_backend/config/redis/RedisConfig.java
@@ -1,12 +1,28 @@
 package com.example.speechmate_backend.config.redis;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -22,5 +38,33 @@ public class RedisConfig {
         config.setHostName(host);  //  명시적으로 설정
         config.setPort(port);
         return new LettuceConnectionFactory(config);
+    }
+
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+// ObjectMapper를 커스터마이징하여 JavaTimeModule 등록
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // Jackson이 클래스 타입 정보를 JSON에 포함하도록 설정
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.EVERYTHING,
+                JsonTypeInfo.As.WRAPPER_ARRAY
+        );
+
+        // 커스텀 ObjectMapper를 사용하는 GenericJackson2JsonRedisSerializer 생성
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer)) // 커스텀 시리얼라이저 적용
+                .entryTtl(Duration.ofMinutes(10));   //캐시 ttl 10분
+
+        return RedisCacheManager.builder(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory))
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
     }
 }

--- a/src/main/java/com/example/speechmate_backend/s3/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/example/speechmate_backend/s3/service/S3UploadPresignedUrlService.java
@@ -90,5 +90,9 @@ public class S3UploadPresignedUrlService {
         return new Date(System.currentTimeMillis() + PRESIGNED_URL_EXPIRATION_MILLIS);
     }
 
+    public void deleteObject(String key) {
+        amazonS3.deleteObject(bucket, key);
+    }
+
 
 }

--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
@@ -45,11 +45,9 @@ public class SpeechController {
     //stt결과로 AI 분석까지.
     @Operation(summary = "3. 텍스트 분석 open api", description = "stt로 변환된 content가 있어야 동작합니다.")
     @PostMapping("/analyze/{speechId}")
-    public ResponseEntity<ApiResponse<SpeechResultDto>> analyzeSpeech(
     public ResponseEntity<ApiResponse<AnalysisResultDto>> analyzeSpeech(
             @PathVariable Long speechId
     ) {
-        SpeechResultDto dto = speechService.analyze(speechId);
         AnalysisResultDto dto = speechService.analyze(speechId);
         return ResponseEntity.ok(ApiResponse.ok(dto));
     }

--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
@@ -46,9 +46,11 @@ public class SpeechController {
     @Operation(summary = "3. 텍스트 분석 open api", description = "stt로 변환된 content가 있어야 동작합니다.")
     @PostMapping("/analyze/{speechId}")
     public ResponseEntity<ApiResponse<SpeechResultDto>> analyzeSpeech(
+    public ResponseEntity<ApiResponse<AnalysisResultDto>> analyzeSpeech(
             @PathVariable Long speechId
     ) {
         SpeechResultDto dto = speechService.analyze(speechId);
+        AnalysisResultDto dto = speechService.analyze(speechId);
         return ResponseEntity.ok(ApiResponse.ok(dto));
     }
 
@@ -155,5 +157,15 @@ public class SpeechController {
         return ResponseEntity.ok(ApiResponse.ok(dto));
     }
 
+    @DeleteMapping("/delete/{speechId}")
+    public ResponseEntity<String> deleteSpeechById(
+        @PathVariable Long speechId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        speechService.deleteSpeechById(speechId, userId);
+
+        return ResponseEntity.ok("삭제 완료");
+    }
 
 }

--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
@@ -166,4 +166,11 @@ public class SpeechController {
         return ResponseEntity.ok("삭제 완료");
     }
 
+
+    @Operation(summary = "mp4 -> mp3 변환(프론트는 신경쓰지마세요)", description = "")
+    @PostMapping("/test/translate/{speechId}")
+    public ResponseEntity<ApiResponse<String>> testtransistion(
+            @PathVariable Long speechId) {
+        return ResponseEntity.ok(ApiResponse.ok(speechService.testtranscription(speechId)));
+    }
 }

--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechRestClient.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechRestClient.java
@@ -1,10 +1,12 @@
 package com.example.speechmate_backend.speech.controller;
 
 import com.amazonaws.services.s3.model.S3Object;
+import com.example.speechmate_backend.common.exception.FFmpegException;
+import com.example.speechmate_backend.common.exception.FileTooLargeException;
 import com.example.speechmate_backend.common.exception.WhisperException;
 import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.service.S3UploadPresignedUrlService;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -20,17 +22,20 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.io.File;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
+@Slf4j
 @Service
 public class SpeechRestClient {
 
     private final RestClient restClient;
     private final WebClient webClient;
     private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    @Value("${ffmpeg.path}")
+    private String ffmpegPath;
 
     public SpeechRestClient(@Value("${spring.ai.openai.api-key}") String openAiApiKey, S3UploadPresignedUrlService s3UploadPresignedUrlService) {
         this.restClient = RestClient.builder()
@@ -136,6 +141,159 @@ public class SpeechRestClient {
             throw WhisperException.EXCEPTION;
         }
     }
+
+    public String transcribeWithFileFromS3(String fileKey) {
+        File tempVideoFile = null;
+        File tempAudioFile = null;
+        S3Object s3Object = null;
+
+        try {
+            log.info("S3에서 파일 다운로드 시작: {}", fileKey);
+            s3Object = s3UploadPresignedUrlService.getObject(fileKey);
+
+            // 1️⃣ 임시 파일로 저장
+            String fileExtension = getFileExtension(fileKey);
+            tempVideoFile = File.createTempFile("speech-temp", "." + fileExtension);
+
+            try (InputStream is = s3Object.getObjectContent()) {
+                Files.copy(is, tempVideoFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            log.info("임시 파일 생성 완료. 크기: {} bytes", tempVideoFile.length());
+
+            // 2️⃣ mp4/mov/m4a는 mp3로 변환
+            if ("mp4".equalsIgnoreCase(fileExtension)
+                    || "mov".equalsIgnoreCase(fileExtension)
+                    || "m4a".equalsIgnoreCase(fileExtension)) {
+
+                tempAudioFile = File.createTempFile("audio-extracted", ".mp3");
+                log.info("ffmpeg 변환 시작");
+                runFfmpegConversion(tempVideoFile, tempAudioFile);
+                log.info("변환 완료. MP3 크기: {} bytes", tempAudioFile.length());
+
+            } else {
+                tempAudioFile = File.createTempFile("audio-original", "." + fileExtension);
+                Files.copy(tempVideoFile.toPath(), tempAudioFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            long fileSizeMB = tempAudioFile.length() / (1024 * 1024);
+            if (fileSizeMB > 25) {
+                log.error("파일 크기 초과: {}MB (최대 25MB)", fileSizeMB);
+                throw FileTooLargeException.EXCEPTION;
+            }
+
+            // 3️⃣ Whisper API 호출
+            log.info("whisper 호출");
+            FileSystemResource fileResource = new FileSystemResource(tempAudioFile);
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+            builder.part("file", fileResource)
+                    .filename("speech." + getFileExtension(tempAudioFile.getName()))
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM);
+            builder.part("model", "whisper-1");
+            builder.part("language", "ko");
+            builder.part("response_format", "text");
+
+            String response = webClient.post()
+                    .uri("/transcriptions")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(builder.build()))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+            log.info("whisper에서 받은 내용: {}",response);
+            return response;
+
+        } catch (Exception e) {
+            log.error("Whisper 변환 중 오류 발생", e);
+            throw WhisperException.EXCEPTION;
+        } finally {
+            if (tempVideoFile != null && tempVideoFile.exists()) tempVideoFile.delete();
+            if (tempAudioFile != null && tempAudioFile.exists()) tempAudioFile.delete();
+            if (s3Object != null) try { s3Object.close(); } catch (Exception ignored) {}
+        }
+    }
+
+
+    //mp4, mov, m4a ->mp3 변환 메소드
+    public String transcribeLargeFile(String fileKey) {
+        File tempVideoFile = null;
+        File tempAudioFile = null;
+        S3Object s3Object = null;
+
+        try {
+            log.info("S3에서 파일 다운로드 시작: {}", fileKey);
+            s3Object = s3UploadPresignedUrlService.getObject(fileKey);
+
+            // 1️⃣ S3 → 임시 비디오/오디오 파일로 저장
+            String fileExtension = getFileExtension(fileKey);
+            tempVideoFile = File.createTempFile("video-temp", "." + fileExtension);
+
+            try (InputStream is = s3Object.getObjectContent()) {
+                Files.copy(is, tempVideoFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            log.info("임시 파일 생성 완료. 크기: {} bytes", tempVideoFile.length());
+
+            // 2️⃣ mp4/mov/m4a는 mp3로 변환, 나머지는 그대로 사용
+            if ("mp4".equalsIgnoreCase(fileExtension)
+                    || "mov".equalsIgnoreCase(fileExtension)
+                    || "m4a".equalsIgnoreCase(fileExtension)) {
+
+                tempAudioFile = File.createTempFile("audio-extracted", ".mp3");
+
+                log.info("ffmpeg 변환 시작");
+                runFfmpegConversion(tempVideoFile, tempAudioFile);
+                log.info("변환 완료. MP3 크기: {} bytes", tempAudioFile.length());
+
+            } else {
+                tempAudioFile = File.createTempFile("audio-original", "." + fileExtension);
+                Files.copy(tempVideoFile.toPath(), tempAudioFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            if (tempAudioFile.length() > 25 * 1024 * 1024) {
+                throw FileTooLargeException.EXCEPTION;
+            }
+
+            return "변환 성공";
+
+        } catch (Exception e) {
+            log.error("Whisper 변환 중 오류 발생", e);
+            throw WhisperException.EXCEPTION;
+        } finally {
+            if (tempVideoFile != null && tempVideoFile.exists()) tempVideoFile.delete();
+            if (tempAudioFile != null && tempAudioFile.exists()) tempAudioFile.delete();
+            if (s3Object != null) try { s3Object.close(); } catch (Exception ignored) {}
+        }
+    }
+
+    // ffmpeg 로컬 파일 변환
+    private void runFfmpegConversion(File inputFile, File outputFile) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(
+                ffmpegPath,
+                "-i", inputFile.getAbsolutePath(),
+                "-vn",
+                "-acodec", "libmp3lame",
+                "-b:a", "128k",
+                "-ar", "44100",
+                "-ac", "2",
+                "-y",
+                outputFile.getAbsolutePath()
+        );
+
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+
+        // 로그 출력
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            reader.lines().forEach(line -> log.info("[FFMPEG] {}", line));
+        }
+
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw FFmpegException.EXECPTION;
+        }
+    }
+
 
     private String getFileExtension(String fileKey) {
         return fileKey.substring(fileKey.lastIndexOf(".")+1).toLowerCase();

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -402,4 +402,20 @@ public AnalysisResultDto getSpeechContentAnalysisById(Long speechId) {
     return AnalysisResultDto.from(speech.getAnalysisResult());
 
 }
+
+    public void deleteSpeechById(Long speechId, Long userId) {
+        Speech speech = speechRepository.findById(speechId).orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
+
+        if(speech.getUser().getId() != userId) {
+            throw UserNotMatchException.EXCEPTION;
+        }
+
+        String fileKey = speech.getFileUrl();
+        if (fileKey != null && !fileKey.isEmpty()) {
+            s3UploadPresignedUrlService.deleteObject(fileKey);
+            log.info("Deleting S3 object: {}", fileKey);
+        }
+
+        speechRepository.delete(speech);
+    }
 }

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -17,8 +17,12 @@ import com.example.speechmate_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +44,8 @@ public class SpeechService {
     private final SpeechAnalysisResultService speechAnalysisResultService;
     private final SpeechRestClient speechRestClient;
     private final SpeechCustomRepository speechCustomRepository;
+    private final CacheManager cacheManager;
+    private final RedisTemplate redisTemplate;
 
     @Value("${spring.ai.openai.api-key}")
     private String openAiApiKey;
@@ -186,7 +192,7 @@ public class SpeechService {
                 throw SpeechFileKeyNotFoundException.EXCEPTION;
             }
 
-            String content = speechRestClient.transcribeversionFromS3(fileKeyFromDb);
+            String content = speechRestClient.transcribeWithFileFromS3(fileKeyFromDb);
             speech.setContent(content);
             speechRepository.save(speech);
 
@@ -197,6 +203,25 @@ public class SpeechService {
 
     }
 
+    // mp4 -> mp3 테스트
+    public String testtranscription(Long speechId) {
+        try {
+            Speech speech = speechRepository.findById(speechId)
+                    .orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
+
+
+            String fileKeyFromDb = speech.getFileUrl();
+            if (fileKeyFromDb == null || fileKeyFromDb.isEmpty()) {
+                // fileKey가 DB에 없는 경우에 대한 예외 처리
+                throw SpeechFileKeyNotFoundException.EXCEPTION;
+            }
+
+            return speechRestClient.transcribeLargeFile(fileKeyFromDb);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Whisper 변환 실패: " + e.getMessage(), e);
+        }
+    }
 
     @Transactional
     public VoiceKeyDto createPresignedUrlS3(Long userId, MediaFileExtension fileExtension) {
@@ -210,6 +235,7 @@ public class SpeechService {
         return dto;
     }
 
+    @CacheEvict(value = "speechFeedCache", allEntries = true)
     @Transactional
     public SpeechS3CallbackDto registerUploadedSpeech(Long userId, String fileKey, Long durationSeconds) {
         User user = userRepository.findById(userId)
@@ -315,6 +341,7 @@ public class SpeechService {
 
 
 @Transactional(readOnly = true)
+@Cacheable(value = "speechFeedCache", key = "#userId + '_' + #lastSpeechId + '_' + #limit + '_' + #sortType")
 public SpeechPagingFeedDto getMySpeecheFeed(Long userId, Long lastSpeechId, int limit, SortType sortType) {
     List<SpeechFeedDto> rawDtos = speechCustomRepository.findMyFeed(userId, lastSpeechId, limit + 1, sortType);
 
@@ -350,7 +377,7 @@ public SpeechPagingFeedDto getMySpeecheFeed(Long userId, Long lastSpeechId, int 
             .build();
 }
 
-
+@CacheEvict(value = "speechFeedCache", allEntries = true)
 @Transactional
 public SpeechIdDto addMetadataToSpeech(Long speechId, SpeechMetadataRequestDto requestDto, Long userId) {
     Speech speech = speechRepository.findById(speechId)

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -68,13 +68,14 @@ public class SpeechService {
 */
 
     @Transactional
-    public SpeechResultDto analyze(Long speechId) {
+    public AnalysisResultDto analyze(Long speechId) {
         Speech speech = speechRepository.findById(speechId)
                 .orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
 
         if (speech.getAnalysisResult() != null) {
+            AnalysisResult res = speech.getAnalysisResult();
             String fileUrl = s3UploadPresignedUrlService.getPublicS3Url(speech.getFileUrl());
-            return SpeechResultDto.from(speech, fileUrl);
+            return AnalysisResultDto.from(res);
             //throw SpeechContentAlreadyExistException.EXCEPTION; // 이미 분석된 경우 종료
         }
 
@@ -90,7 +91,7 @@ public class SpeechService {
             speechRepository.save(speech);
             String fileUrl = s3UploadPresignedUrlService.getPublicS3Url(speech.getFileUrl());
             //log.info("[AI 분석 성공] Speech ID {} 논리 점수: {}", speechId, result.getLogicalCoherenceScore());
-            return SpeechResultDto.from(speech, fileUrl);
+            return AnalysisResultDto.from(result);
         } catch (Exception e) {
             log.error("[AI 분석 실패] Speech ID {}: {}", speechId, e.getMessage(), e);
             // 원하면 AI 실패 시 따로 정의된 예외로 던질 수도 있음

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -60,3 +60,6 @@ management:
   endpoint:
     health:
       show-details: always
+
+ffmpeg:
+  path: /usr/bin/ffmpeg


### PR DESCRIPTION
- 피드 조회시 캐싱
- 스피치 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - DELETE endpoint to remove a speech (auth required) and delete its uploaded file.
  - New endpoints for testing/transcribing large files and a new public S3 delete operation.
  - Automatic server-side conversion of certain uploads to MP3 via FFmpeg for transcription.

- Refactor
  - Analysis response format changed (may affect clients).

- Chores
  - Application-level Redis caching enabled (10-minute TTL) and a Jackson datetime dependency added.

- Bug Fixes
  - Enforced 25MB upload limit with explicit error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->