### PR TITLE
Feat/#31 stt,OpenAI 요청 시 동시성 제어

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
 
             echo "새 컨테이너 준비 대기..."
             READY=false
-            for i in {1..12}; do
+            for i in {1..30}; do
               if curl -s $HEALTH_URL | grep '"status":"UP"' > /dev/null; then
                 READY=true
                 echo "서버 준비 완료 ✅"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
           script: |
             set -e
             cd /home/ubuntu/capstone
+            
+            echo "🔄 최신 이미지 pull..."
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/capstoneback:latest
 
             echo "Creating .env file from GitHub Secrets..."
             echo "${{ secrets.ENV_VARS }}" > ./.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM openjdk:17-jdk-slim
 
 RUN apt-get update && apt-get install -y ffmpeg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk
 
+RUN apt-get update && apt-get install -y ffmpeg
+
 COPY build/libs/*SNAPSHOT.jar /app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,10 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 
+    implementation 'org.redisson:redisson-spring-boot-starter:3.51.0'
+    //h2
+    runtimeOnly 'com.h2database:h2'
+
 }
 
 dependencyManagement {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - TZ=Asia/Seoul
+    volumes:
+      - /usr/bin/ffmpeg:/usr/bin/ffmpeg
     networks:
       - capstone-net
     restart: always
@@ -30,6 +32,8 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - TZ=Asia/Seoul
+    volumes:
+      - /usr/bin/ffmpeg:/usr/bin/ffmpeg
     networks:
       - capstone-net
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - TZ=Asia/Seoul
-    volumes:
-      - /usr/bin/ffmpeg:/usr/bin/ffmpeg
     networks:
       - capstone-net
     restart: always
@@ -32,8 +30,6 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - TZ=Asia/Seoul
-    volumes:
-      - /usr/bin/ffmpeg:/usr/bin/ffmpeg
     networks:
       - capstone-net
     restart: always

--- a/src/main/java/com/example/speechmate_backend/common/aop/AopForTransaction.java
+++ b/src/main/java/com/example/speechmate_backend/common/aop/AopForTransaction.java
@@ -1,0 +1,18 @@
+package com.example.speechmate_backend.common.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션 분리를 위한 클래스
+ */
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/common/aop/CustomSpringELParser.java
+++ b/src/main/java/com/example/speechmate_backend/common/aop/CustomSpringELParser.java
@@ -1,0 +1,26 @@
+package com.example.speechmate_backend.common.aop;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/*
+* CustomSpringELParser 는 전달받은 Lock의 이름을
+* Spring Expression Language 로 파싱하여 읽음
+* */
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+
+}

--- a/src/main/java/com/example/speechmate_backend/common/aop/DistributedLock.java
+++ b/src/main/java/com/example/speechmate_backend/common/aop/DistributedLock.java
@@ -1,0 +1,37 @@
+package com.example.speechmate_backend.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redisson Distributed Lock annotation
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /*
+    * 락의 이름
+    * */
+    String key();
+
+    /*
+    * 락의 시간 단위
+    * */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 30s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제
+     */
+    long leaseTime() default 30L;
+}

--- a/src/main/java/com/example/speechmate_backend/common/aop/DistributedLockAop.java
+++ b/src/main/java/com/example/speechmate_backend/common/aop/DistributedLockAop.java
@@ -1,0 +1,57 @@
+package com.example.speechmate_backend.common.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(com.example.speechmate_backend.common.aop.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());  // (2)
+            if (!available) {
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);  // (3)
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();   // (4)
+            } catch (IllegalMonitorStateException e) {
+                log.warn("Redisson Lock Already UnLock serviceName: {}, key : {}",
+                        method.getName(), key
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -1,6 +1,7 @@
 package com.example.speechmate_backend.speech.service;
 
 import com.example.speechmate_backend.common.ApiResponse;
+import com.example.speechmate_backend.common.aop.DistributedLock;
 import com.example.speechmate_backend.common.exception.*;
 import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.controller.dto.VoiceKeyDto;
@@ -178,7 +179,33 @@ public class SpeechService {
         }
     }
 
+    @DistributedLock(key = "'SPEECH_TRANSCRIBE:' + #speechId")
     public SpeechContentResponse transcribeversionFromS3(Long speechId) {
+        try {
+            Speech speech = speechRepository.findById(speechId)
+                    .orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
+            if (speech.getContent() != null && !speech.getContent().isEmpty()) {
+                return SpeechContentResponse.of(speech.getContent());
+            }
+
+            String fileKeyFromDb = speech.getFileUrl();
+            if (fileKeyFromDb == null || fileKeyFromDb.isEmpty()) {
+                // fileKey가 DB에 없는 경우에 대한 예외 처리
+                throw SpeechFileKeyNotFoundException.EXCEPTION;
+            }
+
+            String content = speechRestClient.transcribeWithFileFromS3(fileKeyFromDb);
+            speech.setContent(content);
+            speechRepository.save(speech);
+
+            return SpeechContentResponse.of(content);
+        } catch (Exception e) {
+            throw new RuntimeException("Whisper 변환 실패: " + e.getMessage(), e);
+        }
+
+    }
+
+    public SpeechContentResponse transcribeversionFromS3WithoutLock(Long speechId) {
         try {
             Speech speech = speechRepository.findById(speechId)
                     .orElseThrow(() -> SpeechNotFoundException.EXCEPTION);

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -431,6 +431,8 @@ public AnalysisResultDto getSpeechContentAnalysisById(Long speechId) {
 
 }
 
+
+    @CacheEvict(value = "speechFeedCache", allEntries = true)
     public void deleteSpeechById(Long speechId, Long userId) {
         Speech speech = speechRepository.findById(speechId).orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
 

--- a/src/main/java/com/example/speechmate_backend/user/domain/User.java
+++ b/src/main/java/com/example/speechmate_backend/user/domain/User.java
@@ -22,9 +22,11 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Speech> speechs = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserSkill> skills = new ArrayList<>();
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,28 @@
+spring:
+  # H2 데이터베이스 설정
+  datasource:
+    # jdbc:h2:mem:testdb -> 'testdb'라는 이름의 인메모리 DB를 사용하겠다는 의미
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa # H2 기본 username
+    password:   # H2 기본 password는 비어있음
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  ai:
+    openai:
+      api-key: dummy-api-key
+  jpa:
+    hibernate:
+      # [중요] 테스트가 시작될 때 스키마(테이블)를 생성하고, 끝나면 삭제하는 설정
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        # H2 DB에 맞는 SQL 문법을 사용하도록 설정
+        dialect: org.hibernate.dialect.H2Dialect
+    # 실행되는 SQL 쿼리를 로그로 보고 싶을 때 활성화
+    show-sql: true
+  jwt:
+    secret: test-secret-key  # JwtUtil 실패 방지
+    expiration: 3600000

--- a/src/test/java/com/example/speechmate_backend/speech/SpeechTest.java
+++ b/src/test/java/com/example/speechmate_backend/speech/SpeechTest.java
@@ -1,0 +1,188 @@
+package com.example.speechmate_backend.speech;
+
+import com.example.speechmate_backend.s3.config.S3Config;
+import com.example.speechmate_backend.s3.service.S3UploadPresignedUrlService;
+import com.example.speechmate_backend.speech.controller.SpeechRestClient;
+import com.example.speechmate_backend.speech.domain.Speech;
+import com.example.speechmate_backend.speech.repository.SpeechCustomRepository;
+import com.example.speechmate_backend.speech.repository.SpeechRepository;
+import com.example.speechmate_backend.speech.service.SpeechAnalysisResultService;
+import com.example.speechmate_backend.speech.service.SpeechService;
+import com.example.speechmate_backend.user.domain.OauthInfo;
+import com.example.speechmate_backend.user.domain.SkillType;
+import com.example.speechmate_backend.user.domain.User;
+import com.example.speechmate_backend.user.domain.UserSkill;
+import com.example.speechmate_backend.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class SpeechTest {
+    @Autowired
+    private SpeechService speechService;
+
+    @Autowired
+    private SpeechRepository speechRepository;
+
+    // 기존 MockBean
+    @MockBean
+    private SpeechRestClient speechRestClient;
+
+    // 추가 MockBean: SpeechService의 다른 의존성들
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    @MockBean
+    private S3Config s3Config;
+
+
+    @MockBean
+    private SpeechAnalysisResultService speechAnalysisResultService;
+
+    @MockBean
+    private SpeechCustomRepository speechCustomRepository;
+
+    @MockBean
+    private CacheManager cacheManager;
+
+    @MockBean
+    private RedisTemplate<String, Object> redisTemplate;  // RedisTemplate 타입 확인 (Object는 예시)
+
+    private Speech speech;
+
+    @BeforeEach
+    void setUp() {
+        speechRepository.deleteAll();
+        OauthInfo oauthInfo = new OauthInfo(); // 실제 OauthInfo 객체
+        speech = new Speech();         // 실제 Speech 객체
+
+// 2. User 객체를 먼저 생성합니다. (skills는 아직 비어있음)
+        User user = User.builder()
+                .id(1L)
+                .oauthInfo(oauthInfo)
+                .build();
+
+// 3. 생성된 user 객체를 참조하여 UserSkill 객체들을 생성합니다.
+        UserSkill skill1 = new UserSkill(user, SkillType.APPROPRIATE_PACE);
+        UserSkill skill2 = new UserSkill(user, SkillType.CLEAR_PRONUNCIATION);
+        speech = new Speech();
+        speech.setFileUrl("test-file-key.mp3");
+
+        user.getSkills().add(skill1);
+        user.getSkills().add(skill2);
+        user.addSpeech(speech);
+        speech.setUser(user);
+        speech = speechRepository.save(speech);
+        // Mock 설정: 필요 시 추가 (예: userRepository가 호출되면 null 반환 등)
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());  // 예시
+    }
+
+    @Test
+    @DisplayName("transcribe 메소드에 동시 요청이 발생해도 분산 락을 적용한 외부 API는 단 1번만 호출된다")
+    void transcribe_should_call_api_only_once_with_distributed_lock() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // [핵심] 가짜 RestClient 설정:
+        // 1. 호출되면 100ms 동안 지연시켜 실제 API처럼 동작하게 만듭니다.
+        // 2. "Mock STT Result" 라는 가짜 결과를 반환합니다.
+        when(speechRestClient.transcribeWithFileFromS3(anyString())).thenAnswer(invocation -> {
+            Thread.sleep(100); // 100ms 지연 시뮬레이션
+            return "Mock STT Result";
+        });
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 여러 스레드가 동시에 같은 speechId에 대해 STT 요청
+                    speechService.transcribeversionFromS3(speech.getId());
+                } catch (Exception e) {
+                    // 락 획득 실패 시 IllegalStateException이 발생할 수 있으나,
+                    // 테스트의 목적은 API 호출 횟수 검증이므로 예외는 무시합니다.
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 끝날 때까지 대기
+        executorService.shutdown();
+
+        // then
+        // [핵심 검증] 10개의 스레드가 경쟁했지만, 비용이 발생하는 speechRestClient의 메소드는
+        // 오직 1번만 호출되었는지 검증합니다.
+        verify(speechRestClient, times(1)).transcribeWithFileFromS3(anyString());
+
+        // 추가 검증: DB에 결과가 잘 저장되었는지 확인
+        Speech resultSpeech = speechRepository.findById(speech.getId()).get();
+        assertThat(resultSpeech.getContent()).isEqualTo("Mock STT Result");
+    }
+
+    @Test
+    @DisplayName("transcribe 메소드에 동시 요청이 발생해도 분산 락을 적용하지 않은 외부 API는 모든 스레드만큼 호출된다")
+    void transcribe_should_call_api_only_once_without_distributed_lock() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // [핵심] 가짜 RestClient 설정:
+        // 1. 호출되면 100ms 동안 지연시켜 실제 API처럼 동작하게 만듭니다.
+        // 2. "Mock STT Result" 라는 가짜 결과를 반환합니다.
+        when(speechRestClient.transcribeWithFileFromS3(anyString())).thenAnswer(invocation -> {
+            Thread.sleep(100); // 100ms 지연 시뮬레이션
+            return "Mock STT Result";
+        });
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 여러 스레드가 동시에 같은 speechId에 대해 STT 요청
+                    speechService.transcribeversionFromS3WithoutLock(speech.getId());
+                } catch (Exception e) {
+                    // 락 획득 실패 시 IllegalStateException이 발생할 수 있으나,
+                    // 테스트의 목적은 API 호출 횟수 검증이므로 예외는 무시합니다.
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 끝날 때까지 대기
+        executorService.shutdown();
+
+        // then
+        // [핵심 검증] 10개의 스레드가 경쟁했지만, 비용이 발생하는 speechRestClient의 메소드는
+        // 오직 1번만 호출되었는지 검증합니다.
+        verify(speechRestClient, times(10)).transcribeWithFileFromS3(anyString());
+
+        // 추가 검증: DB에 결과가 잘 저장되었는지 확인
+        Speech resultSpeech = speechRepository.findById(speech.getId()).get();
+        assertThat(resultSpeech.getContent()).isEqualTo("Mock STT Result");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distributed locking added for transcription to prevent duplicate concurrent API calls.
  * Transaction isolation introduced for locked operations.
  * Added integration tests validating concurrent transcription behavior with and without locking.

* **Bug Fixes**
  * Speech feed now updates immediately after a speech is deleted (cache eviction).

* **Chores**
  * Docker base image switched to slimmer OpenJDK 17 and FFmpeg added.
  * Deployment now pulls latest image before rollout and increases readiness wait time.
  * Added Redis/lock and in-memory test DB dependencies; test config for H2 and local services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->