### PR TITLE
FEAT/5회업로드제한

### DIFF
--- a/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
+++ b/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
@@ -23,8 +23,8 @@ public enum ErrorCode implements ErrorCodeIfs{
     USER_NOT_MATCH("fail", HttpStatus.SC_FORBIDDEN, "현재 로그인 한 유저가 일치하지 않습니다."),
     FILE_TOO_LARGE("fail", HttpStatus.SC_BAD_REQUEST, "파일 크기가 25MB가 넘어갑니다. 작은 파일을 업로드해주세요"),
     FFMPEG_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "파일 변환 중 오류 발생(ffmpeg)"),
-    RETURN_ZERO_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "ReturnZero stt 과정중 오류 발생");
-
+    RETURN_ZERO_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "ReturnZero stt 과정중 오류 발생"),
+    UPLOAD_LIMIT_EXCEED("fail", HttpStatus.SC_TOO_MANY_REQUESTS, "이미 5회 업로드 했습니다.");
 
     private final String status;
     private final Integer resultCode;

--- a/src/main/java/com/example/speechmate_backend/common/exception/UploadLimitExceededException.java
+++ b/src/main/java/com/example/speechmate_backend/common/exception/UploadLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.example.speechmate_backend.common.exception;
+
+import com.example.speechmate_backend.common.error.ErrorCode;
+
+public class UploadLimitExceededException extends SmateException {
+  public static final SmateException EXCEPTION = new UploadLimitExceededException();
+
+    public UploadLimitExceededException() {
+        super(ErrorCode.UPLOAD_LIMIT_EXCEED);
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/config/redis/RedisUtil.java
+++ b/src/main/java/com/example/speechmate_backend/config/redis/RedisUtil.java
@@ -1,10 +1,13 @@
 package com.example.speechmate_backend.config.redis;
 
+import com.example.speechmate_backend.common.exception.UploadLimitExceededException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
@@ -39,5 +42,17 @@ public class RedisUtil {
 
     public void deleteRefreshToken(String userId) {
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    public void uploadlimit(String userId) {
+        String key = "upload:" + userId + ":" + LocalDate.now();
+        Long count = redisTemplate.opsForValue().increment(key);
+        if(count == 1) {
+            long ttl = Duration.between(LocalDateTime.now(), LocalDate.now().plusDays(1).atStartOfDay()).getSeconds();
+            redisTemplate.expire(key, ttl, TimeUnit.SECONDS);
+        }
+        if(count > 5) {
+            throw UploadLimitExceededException.EXCEPTION;
+        }
     }
 }

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -3,6 +3,7 @@ package com.example.speechmate_backend.speech.service;
 import com.example.speechmate_backend.common.ApiResponse;
 import com.example.speechmate_backend.common.aop.DistributedLock;
 import com.example.speechmate_backend.common.exception.*;
+import com.example.speechmate_backend.config.redis.RedisUtil;
 import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.controller.dto.VoiceKeyDto;
 import com.example.speechmate_backend.s3.service.S3UploadPresignedUrlService;
@@ -45,6 +46,7 @@ public class SpeechService {
     private final SpeechRestClient speechRestClient;
     private final SpeechCustomRepository speechCustomRepository;
     private final ReturnZeroClient returnZeroClient;
+    private final RedisUtil redisUtil;
 
     @Value("${spring.ai.openai.api-key}")
     private String openAiApiKey;
@@ -235,6 +237,7 @@ public class SpeechService {
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
         log.info("userID: " + userId);
 
+        redisUtil.uploadlimit(String.valueOf(userId));
         // 2. Presigned URL 발급
         VoiceKeyDto dto = s3UploadPresignedUrlService.generatePreSignedUrlForSpeech(userId, fileExtension);
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,6 +10,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      password: redis1234
   ai:
     openai:
       api-key: dummy-api-key
@@ -26,3 +27,7 @@ spring:
   jwt:
     secret: test-secret-key  # JwtUtil 실패 방지
     expiration: 3600000
+
+returnzero:
+  client-id: dummy-client-id
+  client-secret: dummy-client-secret

--- a/src/test/java/com/example/speechmate_backend/speech/SpeechTest.java
+++ b/src/test/java/com/example/speechmate_backend/speech/SpeechTest.java
@@ -1,11 +1,14 @@
 package com.example.speechmate_backend.speech;
 
+import com.example.speechmate_backend.common.exception.UploadLimitExceededException;
+import com.example.speechmate_backend.config.redis.RedisUtil;
 import com.example.speechmate_backend.s3.config.S3Config;
 import com.example.speechmate_backend.s3.service.S3UploadPresignedUrlService;
 import com.example.speechmate_backend.speech.controller.SpeechRestClient;
 import com.example.speechmate_backend.speech.domain.Speech;
 import com.example.speechmate_backend.speech.repository.SpeechCustomRepository;
 import com.example.speechmate_backend.speech.repository.SpeechRepository;
+import com.example.speechmate_backend.speech.returnzero.ReturnZeroClient;
 import com.example.speechmate_backend.speech.service.SpeechAnalysisResultService;
 import com.example.speechmate_backend.speech.service.SpeechService;
 import com.example.speechmate_backend.user.domain.OauthInfo;
@@ -30,6 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -45,6 +49,9 @@ public class SpeechTest {
     // 기존 MockBean
     @MockBean
     private SpeechRestClient speechRestClient;
+
+    @Autowired
+    private RedisUtil redisUtil;
 
     // 추가 MockBean: SpeechService의 다른 의존성들
     @MockBean
@@ -68,6 +75,10 @@ public class SpeechTest {
 
     @MockBean
     private RedisTemplate<String, Object> redisTemplate;  // RedisTemplate 타입 확인 (Object는 예시)
+
+    @MockBean
+    private ReturnZeroClient returnZeroClient;
+
 
     private Speech speech;
 
@@ -184,4 +195,19 @@ public class SpeechTest {
         Speech resultSpeech = speechRepository.findById(speech.getId()).get();
         assertThat(resultSpeech.getContent()).isEqualTo("Mock STT Result");
     }
+
+    @Test
+    @DisplayName("같은 날 6번째 업로드 시도 시 UploadLimitExceededException 발생")
+    void uploadLimitExceeded_after_five_requests() {
+        String userId = "123";
+        // 5번은 통과
+        for (int i = 0; i < 5; i++) {
+            redisUtil.uploadlimit(userId);
+        }
+
+        // 6번째는 예외 발생
+        assertThrows(UploadLimitExceededException.class,
+                () -> redisUtil.uploadlimit(userId));
+    }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added daily upload rate limit: users can upload up to 5 times per day. Exceeding the limit blocks further uploads and returns a clear “Too Many Requests (429)” error message.
  - Limit is enforced during presigned URL generation for uploads.

- Tests
  - Added test to verify the upload limit is enforced after five requests.

- Chores
  - Updated test configuration for Redis and external client credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->