### PR TITLE
FEAT/ 타임스탬프 같이 반환 및 토큰 에러 수정

### DIFF
--- a/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/SpeechController.java
@@ -63,7 +63,7 @@ public class SpeechController {
 
     @Operation(summary = "2. rtzr api (stt)", description = "저장된 s3 파일로부터 stt로변환된 내용을 뽑아냅니다.(1을 먼저 선행하여 s3에 파일 저장후 요청해주세요")
     @PostMapping(value = "/rtzrstt/{speechId}")
-    public ResponseEntity<ApiResponse<SpeechContentResponse>> transcribesRtzr(
+    public ResponseEntity<ApiResponse<SpeechSentenceResponse>> transcribesRtzr(
             @Parameter(description = "stt변환을 진행할 speechId", required = true)
             @PathVariable Long speechId) {
         return ResponseEntity.ok(ApiResponse.ok(speechService.rtzrStt(speechId)));

--- a/src/main/java/com/example/speechmate_backend/speech/controller/dto/SentenceDto.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/dto/SentenceDto.java
@@ -1,0 +1,10 @@
+package com.example.speechmate_backend.speech.controller.dto;
+
+public record SentenceDto(
+        int startTime,
+        String sentence
+) {
+    public static SentenceDto from(TranscriptionResponse.Utterance utterance) {
+        return new SentenceDto(utterance.start_at(), utterance.msg());
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/speech/controller/dto/SpeechSentenceResponse.java
+++ b/src/main/java/com/example/speechmate_backend/speech/controller/dto/SpeechSentenceResponse.java
@@ -1,0 +1,11 @@
+package com.example.speechmate_backend.speech.controller.dto;
+
+import java.util.List;
+
+public record SpeechSentenceResponse(
+        List<SentenceDto> sentences
+) {
+    public static SpeechSentenceResponse of(List<SentenceDto> sentences) {
+        return new SpeechSentenceResponse(sentences);
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/speech/domain/Speech.java
+++ b/src/main/java/com/example/speechmate_backend/speech/domain/Speech.java
@@ -20,6 +20,10 @@ public class Speech extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String content;  //stt변환 결과
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String rawTranscription; // vito.ai 원본 JSON 저장용
+
     private String title; // 발표 파일 이름
 
     private String presentationContext; // 발표 상황
@@ -62,6 +66,10 @@ public class Speech extends BaseEntity {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public void setRawTranscription(String rawTranscription) {
+        this.rawTranscription = rawTranscription;
     }
 
     public void setUser(User user) {

--- a/src/main/java/com/example/speechmate_backend/speech/domain/VerbalAnalysisResult.java
+++ b/src/main/java/com/example/speechmate_backend/speech/domain/VerbalAnalysisResult.java
@@ -28,6 +28,24 @@ public class VerbalAnalysisResult {
     @Lob
     private String repeatedWordsJson; // 반복 단어/횟수 JSON
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String sentencesJson;
+
     // getter, setter, constructor
+    public void setSentencesJson(String sentencesJson) {
+        this.sentencesJson = sentencesJson;
+    }
+
+    public void setSpeech(Speech speech) {
+        this.speech = speech;
+    }
+
+    public void updateAnalysis(long wordCnt, long syllableCnt, String silenceJson, String fillerJson) {
+        this.wordCnt = wordCnt;
+        this.syllableCnt = syllableCnt;
+        this.silenceJson = silenceJson;
+        this.fillerJson = fillerJson;
+    }
 }
 

--- a/src/main/java/com/example/speechmate_backend/speech/domain/converter/VerbalAnalysisConverter.java
+++ b/src/main/java/com/example/speechmate_backend/speech/domain/converter/VerbalAnalysisConverter.java
@@ -25,16 +25,21 @@ public class VerbalAnalysisConverter {
                              List<Silence> silenceList,
                              Map<String, List<Integer>> fillerUsage) throws JsonProcessingException {
 
-        VerbalAnalysisResult result = new VerbalAnalysisResult();
-        result.setSpeech(speech);
-        result.setWordCnt(wordCnt);
-        result.setSyllableCnt(syllableCnt);
+        VerbalAnalysisResult result = speech.getVerbalAnalysisResult();
 
-        // JSON 직렬화
-        result.setSilenceJson(objectMapper.writeValueAsString(silenceList));
-        result.setFillerJson(objectMapper.writeValueAsString(fillerUsage));
+        // 2. 연결된 것이 없다면, 'speech_id'로 DB에서 '고아 레코드'가 있는지 조회
+        if (result == null) {
+            result = repository.findBySpeechId(speech.getId())
+                    .orElseGet(VerbalAnalysisResult::new); // DB에도 없으면 'new'로 새로 생성
+        }
 
-        repository.save(result);
+        // 3. 'result' 객체의 필드 값 업데이트 (DB 저장 X, 메모리에서만)
+        String silenceJson = objectMapper.writeValueAsString(silenceList);
+        String fillerJson = objectMapper.writeValueAsString(fillerUsage);
+
+        // (VerbalAnalysisResult에 만들어둔 update 메서드 호출)
+        result.updateAnalysis(wordCnt, syllableCnt, silenceJson, fillerJson);
+
         speech.setVerbalAnalysisResult(result);
     }
 

--- a/src/main/java/com/example/speechmate_backend/speech/repository/VerbalAnalysisResultRepository.java
+++ b/src/main/java/com/example/speechmate_backend/speech/repository/VerbalAnalysisResultRepository.java
@@ -3,5 +3,8 @@ package com.example.speechmate_backend.speech.repository;
 import com.example.speechmate_backend.speech.domain.VerbalAnalysisResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VerbalAnalysisResultRepository extends JpaRepository<VerbalAnalysisResult, Long> {
+    Optional<VerbalAnalysisResult> findBySpeechId(Long id);
 }

--- a/src/main/java/com/example/speechmate_backend/speech/returnzero/ReturnZeroTokenManager.java
+++ b/src/main/java/com/example/speechmate_backend/speech/returnzero/ReturnZeroTokenManager.java
@@ -9,7 +9,9 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 
 @Slf4j
@@ -53,8 +55,28 @@ public class ReturnZeroTokenManager {
 
         if (response != null && response.containsKey("access_token")) {
             this.accessToken = (String) response.get("access_token");
-            int expireAt = (int) response.get("expire_at");
-            this.tokenExpiresAt = LocalDateTime.now().plusSeconds(expireAt).minusMinutes(1);
+
+            Object expireAtObj = response.get("expire_at");
+            long expireAtTimestamp;
+
+            if (expireAtObj instanceof Number) {
+                expireAtTimestamp = ((Number) expireAtObj).longValue();
+            } else {
+                // 예외 처리 (String 등으로 올 경우)
+                try {
+                    expireAtTimestamp = Long.parseLong(expireAtObj.toString());
+                } catch (NumberFormatException e) {
+                    log.error("ReturnZero 'expire_at' 필드 파싱 실패: {}", expireAtObj);
+                    throw new RuntimeException("ReturnZero 토큰 응답 파싱 실패");
+                }
+            }
+
+            // Unix 타임스탬프(초)를 LocalDateTime으로 변환합니다.
+            this.tokenExpiresAt = LocalDateTime.ofInstant(
+                    Instant.ofEpochSecond(expireAtTimestamp), // Unix 타임스탬프(초) -> Instant
+                    ZoneId.systemDefault()                    // 시스템 기본 시간대
+            ).minusMinutes(1);
+
             log.info("새로운 RTZR 액세스 토큰이 발급되었습니다. 만료 시간: {}", tokenExpiresAt);
         } else {
             log.error("토큰 발급 실패: {}", response);

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -18,6 +18,8 @@ import com.example.speechmate_backend.speech.repository.SpeechRepository;
 import com.example.speechmate_backend.speech.returnzero.ReturnZeroClient;
 import com.example.speechmate_backend.user.domain.User;
 import com.example.speechmate_backend.user.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,6 +49,7 @@ public class SpeechService {
     private final SpeechCustomRepository speechCustomRepository;
     private final ReturnZeroClient returnZeroClient;
     private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
 
     @Value("${spring.ai.openai.api-key}")
     private String openAiApiKey;
@@ -84,28 +87,101 @@ public class SpeechService {
     }
 
     @DistributedLock(key = "'SPEECH_TRANSCRIBE:' + #speechId")
-    public SpeechContentResponse rtzrStt(Long speechId) {
+    public SpeechSentenceResponse rtzrStt(Long speechId) {
         try {
             Speech speech = speechRepository.findById(speechId)
                     .orElseThrow(() -> SpeechNotFoundException.EXCEPTION);
-            if (speech.getContent() != null && !speech.getContent().isEmpty()) {
-                return SpeechContentResponse.of(speech.getContent());
+
+            TranscriptionResponse transcriptionResponse;
+            String rawJson = speech.getRawTranscription();
+
+            // ✅ 1. 'isNewAnalysis' -> 'needsNewAnalysis'로 이름 변경 (더 명확하게)
+            boolean needsNewAnalysis = false;
+
+            if (rawJson != null && !rawJson.isEmpty()) {
+                // [캐시 있음]
+                log.info("DB에서 STT JSON 원본을 로드합니다. (Speech ID: {})", speechId);
+                transcriptionResponse = objectMapper.readValue(rawJson, TranscriptionResponse.class);
+
+                // 캐시는 있지만, 분석 결과가 없으면 새로 분석 필요
+                if (speech.getVerbalAnalysisResult() == null) {
+                    log.warn("Speech ID {}: STT 캐시는 있으나 분석 결과가 없어, 재분석합니다.", speech.getId());
+                    needsNewAnalysis = true;
+                }
+            } else {
+                // [캐시 없음]
+                log.info("vito.ai API를 호출하여 STT를 진행합니다. (Speech ID: {})", speechId);
+
+                String fileKeyFromDb = speech.getFileUrl();
+                if (fileKeyFromDb == null || fileKeyFromDb.isEmpty()) {
+                    throw SpeechFileKeyNotFoundException.EXCEPTION;
+                }
+
+                String rtzrId = returnZeroClient.rtzrSttFromS3(fileKeyFromDb);
+                transcriptionResponse = returnZeroClient.rtzrTranscription(rtzrId);
+
+                String jsonResponse = objectMapper.writeValueAsString(transcriptionResponse);
+                speech.setRawTranscription(jsonResponse);
+                needsNewAnalysis = true; // 새로 API 호출했으니 무조건 분석 필요
             }
 
-            String fileKeyFromDb = speech.getFileUrl();
-            if (fileKeyFromDb == null || fileKeyFromDb.isEmpty()) {
-                // fileKey가 DB에 없는 경우에 대한 예외 처리
-                throw SpeechFileKeyNotFoundException.EXCEPTION;
+            // ✅ 2. '새로 분석이 필요할 때만' verbalanalyze 호출 및 저장
+            if (needsNewAnalysis) {
+                log.info("Speech ID {}: 음성 분석(verbalanalyze)을 실행합니다.", speech.getId());
+                // 2-1. 분석 실행 (내부에서 VerbalAnalysisResult 생성 및 speech에 연결)
+                speechAnalysisResultService.verbalanalyze(speech, transcriptionResponse);
+
+                // 2-2. 'speech' 저장 (rawTranscription, 신규 VerbalAnalysisResult가 Cascade로 저장됨)
+                speechRepository.save(speech);
+                log.info("Speech 엔티티에 rawTranscription 및 새 분석 결과를 저장했습니다.");
             }
 
-            String rtzrId = returnZeroClient.rtzrSttFromS3(fileKeyFromDb);
-            TranscriptionResponse transcriptionResponse = returnZeroClient.rtzrTranscription(rtzrId);
-            String content = speechAnalysisResultService.verbalanalyze(speech, transcriptionResponse);
+            // ✅ 3. 불필요한 fileKeyFromDb 중복 체크 제거
+            // String fileKeyFromDb = speech.getFileUrl(); ... (이 부분 삭제)
 
-            speechRepository.save(speech);
+            // 4. 프론트엔드 반환용 DTO 생성
+            List<SentenceDto> sentences;
+            if (transcriptionResponse.results() == null || transcriptionResponse.results().utterances() == null) {
+                sentences = Collections.emptyList();
+            } else {
+                sentences = transcriptionResponse.results().utterances().stream()
+                        .map(SentenceDto::from)
+                        .collect(Collectors.toList());
+            }
 
-            return SpeechContentResponse.of(content);
+            // 5. 'sentencesJson' 저장 (이미 저장되어 있다면 중복 저장 방지)
+            VerbalAnalysisResult verbalResult = speech.getVerbalAnalysisResult();
+
+            if (verbalResult == null) {
+                // 이 로직이 실행되면 심각한 오류 (needsNewAnalysis=true일 때 생성되었어야 함)
+                log.error("Speech ID {}: 'sentencesJson' 저장 시점에 VerbalAnalysisResult가 null입니다.", speech.getId());
+                throw new IllegalStateException("VerbalAnalysisResult가 존재하지 않습니다.");
+            }
+
+            // ✅ 6. 'sentencesJson' 필드가 비어있을 때만 새로 저장 (불필요한 DB UPDATE 방지)
+            if (verbalResult.getSentencesJson() == null || verbalResult.getSentencesJson().isEmpty()) {
+                try {
+                    String sentencesJson = objectMapper.writeValueAsString(sentences);
+                    verbalResult.setSentencesJson(sentencesJson);
+
+                    // speech를 저장하여 verbalResult의 변경사항(sentencesJson)을 UPDATE
+                    speechRepository.save(speech);
+                    log.info("VerbalAnalysisResult에 sentencesJson을 저장했습니다.");
+
+                } catch (JsonProcessingException e) {
+                    log.error("sentences DTO 'List<SentenceDto>' JSON 직렬화 오류", e);
+                    // 이 저장이 실패해도, 사용자에게 응답은 정상적으로 반환합니다.
+                }
+            }
+
+            // 7. 최종 응답 반환
+            return SpeechSentenceResponse.of(sentences);
+
+        } catch (JsonProcessingException e) {
+            log.error("STT JSON 직렬화/역직렬화 오류 발생", e);
+            throw new RuntimeException("JSON 처리 중 오류가 발생했습니다.", e);
         } catch (Exception e) {
+            log.error("rtzrStt 처리 중 예외 발생", e);
             throw ReturnZeroException.EXCEPTION;
         }
 


### PR DESCRIPTION
기존에 대본전체를 반환하는 것에서 각 한 문장씩 start timestamp와 문장 내용을 반환 토큰 만료 시간을 잘못 설정한 것을 수정함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transcription API now returns sentence-level data with timing information for enhanced analysis granularity.

* **Refactor**
  * Improved transcription data storage and caching mechanisms.
  * Enhanced token expiry calculation for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->