### PR TITLE
feat: Presigned URL 보안 강화 및 비언어 분석 장애 복구 로직 추가

### DIFF
--- a/AI/spring_callback.py
+++ b/AI/spring_callback.py
@@ -1,42 +1,39 @@
 # spring_callback.py
 import requests
 import os
+import time
 import logging
 
 log = logging.getLogger(__name__)
 
-# Spring 서버의 콜백 URL (환경 변수 또는 설정 파일로 관리)
-SPRING_CALLBACK_URL = os.getenv(
-    "SPRING_CALLBACK_URL"
-)
+SPRING_CALLBACK_URL = os.getenv("SPRING_CALLBACK_URL")
+
+_RETRY_DELAYS = [5, 15, 45]
 
 
 def send_callback_to_spring(speech_id: int, analysis_result: dict, status: str):
-    """
-    분석 결과를 Spring 서버의 콜백 API로 전송합니다.
-    """
-
-    # 1. Spring DTO 형식에 맞는 페이로드(Payload) 구성
-    # (NonVerbalAnalysisCallbackRequest)
     payload = {
         "speechId": speech_id,
-        "response": analysis_result  # (성공 시)
+        "response": None if status == "FAILED" else analysis_result,
     }
 
-    # 2. [신규] 실패 시 'response'를 null로 설정
-    if status == "FAILED":
-        payload["response"] = None
-
-    try:
-        response = requests.post(SPRING_CALLBACK_URL, json=payload, timeout=60)
-
-        if 200 <= response.status_code < 300:
-            log.info(f"Spring 콜백 성공 (Speech ID: {speech_id}, Status: {status})")
-        else:
+    for attempt, delay in enumerate(_RETRY_DELAYS, 1):
+        try:
+            response = requests.post(SPRING_CALLBACK_URL, json=payload, timeout=60)
+            if 200 <= response.status_code < 300:
+                log.info(f"Spring 콜백 성공 (speechId={speech_id}, attempt={attempt})")
+                return
             log.warning(
-                f"Spring 콜백 실패 (Speech ID: {speech_id}) - "
-                f"Status: {response.status_code}, Body: {response.text}"
+                f"Spring 콜백 비정상 응답 (speechId={speech_id}, attempt={attempt}) - "
+                f"status={response.status_code}, body={response.text}"
             )
+        except requests.exceptions.RequestException as e:
+            log.error(f"Spring 콜백 요청 실패 (speechId={speech_id}, attempt={attempt}): {e}")
 
-    except requests.exceptions.RequestException as e:
-        log.error(f"Spring 콜백 전송 실패 (Speech ID: {speech_id}) - 오류: {e}")
+        if attempt < len(_RETRY_DELAYS):
+            time.sleep(delay)
+
+    log.critical(
+        f"Spring 콜백 {len(_RETRY_DELAYS)}회 재시도 모두 실패 (speechId={speech_id}). "
+        f"Spring 타임아웃 스케줄러에서 FAILED 처리 예정."
+    )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 명령어
+
+```bash
+# 빌드 (테스트 제외)
+./gradlew clean build -x test
+
+# 테스트 실행
+./gradlew test
+
+# 특정 테스트 클래스 실행
+./gradlew test --tests "com.example.speechmate_backend.speech.SpeechTest"
+
+# 로컬 실행 (MySQL + Redis 먼저 실행 필요)
+./gradlew bootRun --args='--spring.profiles.active=local'
+
+# 전체 로컬 인프라 실행 (Spring + MySQL + Redis + Nginx + AI 워커)
+docker compose up -d
+
+# 모니터링 스택 실행 (Prometheus + Grafana)
+cd infra && docker compose -f docker-compose.monitoring.yml up -d
+```
+
+기본 프로파일은 `local`(`src/main/resources/application.yml`에서 설정). `local` 프로파일은 `127.0.0.1:3306/speechmate`와 로컬 Redis(6379)에 연결한다. `dev` 프로파일은 운영 Docker 컨테이너에서 사용한다.
+
+FFmpeg가 로컬에 설치되어 있어야 하며, 경로는 프로파일별로 `ffmpeg.path`에 설정한다(`application-local.yml`은 Windows 경로, `application-dev.yml`은 `/usr/bin/ffmpeg`).
+
+## 아키텍처
+
+### 시스템 개요
+
+두 개의 런타임이 협력한다:
+- **Spring Boot 3.3.4 (Java 17)** — 메인 REST API (`src/main/java/com/example/speechmate_backend/`)
+- **Python FastAPI 워커** — 비언어적 영상 분석 (`AI/`, 포트 8000)
+
+두 서버 간 통신은 **Redis Streams**를 사용한다. Spring이 `nonverbal-analysis-jobs` 스트림에 작업을 발행하면, Python 워커가 소비하여 분석 완료 후 `/api/callback/speech/non-verbal`로 콜백을 보낸다.
+
+### Spring Boot 패키지 구조
+
+| 패키지 | 역할 |
+|---|---|
+| `speech` | 핵심 도메인: 업로드, STT, AI 분석, 피드 |
+| `user` | 유저 엔티티, 로그인/로그아웃, 토큰 재발급 |
+| `oauth` | 카카오 OIDC 로그인 (JWKS로 ID 토큰 검증) |
+| `s3` | AWS S3 Presigned URL 발급 및 오브젝트 관리 |
+| `fcm` | Firebase Cloud Messaging 푸시 알림 |
+| `config.security` | JWT 필터, Stateless Spring Security 설정 |
+| `common` | `ApiResponse<T>` 래퍼, `BaseEntity`, `@DistributedLock` AOP, 전역 예외 핸들러 |
+
+### 스피치 분석 흐름
+
+1. **업로드**: `POST /api/speech/presignedWithS3` → Presigned URL 발급 → 클라이언트가 S3에 직접 파일 업로드 → `POST /api/speech/s3-callback`으로 `Speech` 엔티티 등록
+2. **STT(언어적 분석)**: `POST /api/speech/rtzrstt/{speechId}` — S3에서 파일 다운로드, FFmpeg로 MP3 변환, ReturnZero(vito.ai) 제출, 완료 폴링, 원본 JSON 저장 + 침묵 구간·간투어·어절/음절 수 추출 → `VerbalAnalysisResult` 저장
+3. **텍스트 분석**: `POST /api/speech/analyze/{speechId}` — Spring AI로 GPT-4o-mini에 대본 전송, 구조화된 `GptResponse`(요약, 키워드, 개선점, 피드백, 예상 질문, 반복 단어) 파싱 → `AnalysisResult` 저장
+4. **비언어적 분석**: `POST /api/speech/nonverbal/{speechId}` — Redis Stream에 작업 발행 → Python 워커가 S3에서 영상 다운로드 후 분석 → 콜백 수신 → `NonVerbalAnalysisResult` 저장. 상태는 `AnalysisStatus` 열거형으로 추적(`NOT_STARTED` → `IN_PROGRESS` → `COMPLETED/FAILED`)
+
+### 주요 패턴
+
+**`@DistributedLock`** — Redisson 기반 분산 락 어노테이션. STT 중복 처리 방지에 사용. `DistributedLockAop`가 `AopForTransaction`을 통해 별도 트랜잭션 안에서 메서드를 실행하여 커밋 전 락 해제를 방지한다.
+
+**`ApiResponse<T>`** — 모든 REST 엔드포인트의 공통 응답 래퍼. 커스텀 예외는 `SmateException`을 상속하며 `ErrorCodeIfs`로 에러 코드를 정의한다. `GlobalExceptionHandler`에서 일괄 처리.
+
+**커서 기반 페이지네이션** — 피드·목록 API는 `lastSpeechId` + `limit` 커서 방식 사용(offset/`Page<>` 미사용). 커스텀 쿼리는 `SpeechCustomRepositoryImpl`(QueryDSL)에 위치.
+
+**JWT 인증** — `JwtFilter`가 Spring Security 필터 앞에 동작. Access + Refresh 토큰 발급; Refresh 토큰은 Redis에 저장, 로그아웃 시 블랙리스트 처리. 재발급 엔드포인트: `/api/auth/reissue`.
+
+**카카오 OIDC** — 서버 사이드 리다이렉트 없이 프론트가 ID 토큰을 직접 전달. `https://kauth.kakao.com`의 JWKS로 토큰 검증.
+
+### 인프라
+
+운영 환경은 EC2에서 GitHub Actions(`.github/workflows/deploy.yml`)으로 **블루-그린 배포**를 수행한다. `dev` 브랜치 푸시 시 빌드 → Docker 이미지 푸시 → SSH 배포 → Nginx가 `capstone-server-blue`(8080)와 `capstone-server-green`(8081) 사이를 전환한다. 헬스체크 실패 시 자동 롤백.
+
+모니터링: Prometheus가 `/actuator/prometheus`를 스크랩, Grafana 대시보드는 포트 3000. Redis 메트릭은 `redis_exporter`로 수집.
+
+### 외부 서비스 의존성
+
+| 서비스 | 용도 | 설정 키 |
+|---|---|---|
+| AWS S3 | 파일 저장소 | `cloud.aws.*` |
+| ReturnZero (vito.ai) | 한국어 STT | `returnzero.*` |
+| OpenAI (GPT-4o-mini + Whisper) | 텍스트 분석 및 STT 폴백 | `spring.ai.openai.*` |
+| 카카오 | OIDC 로그인 | `oauth.kakao.*` |
+| Firebase | FCM 푸시 알림 | `firebase.key` |
+| Redis (Redisson) | 분산 락, 토큰 저장소, 작업 스트림 | `spring.data.redis.*` |
+| MySQL | 기본 데이터 저장소 | `spring.datasource.*` |

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     //actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.prometheus:prometheus-metrics-exposition-formats:1.3.0'
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - "6379:6379"
     env_file:
       - .env
-    command: [ "redis-server", "--requirepass", "${REDIS_PASSWORD}" ]
+    command: [ "redis-server", "--requirepass", "${REDIS_PASSWORD}", "--maxmemory", "1gb", "--maxmemory-policy", "noeviction" ]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/infra/conf/prometheus.yml
+++ b/infra/conf/prometheus.yml
@@ -5,4 +5,15 @@ scrape_configs:
   - job_name: 'spring-app'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['server:8080']
+      - targets: ['host.docker.internal:8080']
+
+
+  # 💡 [여기에 추가됨] 프로메테우스가 redis-exporter의 데이터를 가져오도록 설정
+  - job_name: 'redis'
+    static_configs:
+      - targets: [ 'redis-exporter:9121' ]
+
+  - job_name: 'python-ai-server'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: [ 'host.docker.internal:8000' ] # 예: '192.168.0.5:8000'

--- a/infra/docker-compose.monitoring.yml
+++ b/infra/docker-compose.monitoring.yml
@@ -1,9 +1,12 @@
+name: monitoring
+
 services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
     volumes:
-      - /home/ubuntu/capstone/conf/prometheus.yml:/etc/prometheus/prometheus.yml
+#      - /home/ubuntu/capstone/conf/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./conf/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
     networks:
@@ -23,31 +26,43 @@ services:
     depends_on:
       - prometheus
 
-  loki:
-    image: grafana/loki:latest
-    container_name: loki
-    command: -config.file=/mnt/config/config.yml
-    volumes:
-      - /home/ubuntu/capstone/conf/loki-config.yml:/mnt/config/config.yml:ro
-    ports:
-      - "3100:3100"
-    networks:
-      - capstone-net
-    restart: always
+#  loki:
+#    image: grafana/loki:latest
+#    container_name: loki
+#    command: -config.file=/mnt/config/config.yml
+#    volumes:
+#      - /home/ubuntu/capstone/conf/loki-config.yml:/mnt/config/config.yml:ro
+#    ports:
+#      - "3100:3100"
+#    networks:
+#      - capstone-net
+#    restart: always
+#
+#  promtail:
+#    container_name: promtail
+#    image: grafana/promtail:latest
+#    command: -config.file=/etc/promtail/config.yml
+#    volumes:
+#      - /home/ubuntu/capstone/conf/promtail-config.yml:/etc/promtail/config.yml
+#      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+#      - /var/run/docker.sock:/var/run/docker.sock
+#    networks:
+#      - capstone-net
+#    restart: always
+#    depends_on:
+#      - loki
 
-  promtail:
-    container_name: promtail
-    image: grafana/promtail:latest
-    command: -config.file=/etc/promtail/config.yml
-    volumes:
-      - /home/ubuntu/capstone/conf/promtail-config.yml:/etc/promtail/config.yml
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    container_name: redis-exporter
+    environment:
+      - REDIS_ADDR=redis://host.docker.internal:6379
+      - REDIS_PASSWORD=redis1234
+    ports:
+      - "9121:9121"
     networks:
       - capstone-net
     restart: always
-    depends_on:
-      - loki
 
 networks:
   capstone-net:

--- a/src/main/java/com/example/speechmate_backend/SpeechMateBackendApplication.java
+++ b/src/main/java/com/example/speechmate_backend/SpeechMateBackendApplication.java
@@ -6,8 +6,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @EnableConfigurationProperties(value = {KakaoProperties.class})
 @EnableFeignClients
 @SpringBootApplication

--- a/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
+++ b/src/main/java/com/example/speechmate_backend/common/error/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode implements ErrorCodeIfs{
     FILE_TOO_LARGE("fail", HttpStatus.SC_BAD_REQUEST, "파일 크기가 25MB가 넘어갑니다. 작은 파일을 업로드해주세요"),
     FFMPEG_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "파일 변환 중 오류 발생(ffmpeg)"),
     RETURN_ZERO_EXCEPTION("fail", HttpStatus.SC_INTERNAL_SERVER_ERROR, "ReturnZero stt 과정중 오류 발생"),
-    UPLOAD_LIMIT_EXCEED("fail", HttpStatus.SC_TOO_MANY_REQUESTS, "이미 5회 업로드 했습니다.");
+    UPLOAD_LIMIT_EXCEED("fail", HttpStatus.SC_TOO_MANY_REQUESTS, "이미 5회 업로드 했습니다."),
+    INVALID_FILE_EXTENSION("fail", HttpStatus.SC_BAD_REQUEST, "허용되지 않는 파일 확장자입니다.");
 
     private final String status;
     private final Integer resultCode;

--- a/src/main/java/com/example/speechmate_backend/common/exception/InvalidFileExtensionException.java
+++ b/src/main/java/com/example/speechmate_backend/common/exception/InvalidFileExtensionException.java
@@ -1,0 +1,11 @@
+package com.example.speechmate_backend.common.exception;
+
+import com.example.speechmate_backend.common.error.ErrorCode;
+
+public class InvalidFileExtensionException extends SmateException {
+    public static final SmateException EXCEPTION = new InvalidFileExtensionException();
+
+    public InvalidFileExtensionException() {
+        super(ErrorCode.INVALID_FILE_EXTENSION);
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/s3/domain/PendingUpload.java
+++ b/src/main/java/com/example/speechmate_backend/s3/domain/PendingUpload.java
@@ -1,0 +1,35 @@
+package com.example.speechmate_backend.s3.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class PendingUpload {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String s3Key;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public PendingUpload(String s3Key, Long userId) {
+        this.s3Key = s3Key;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/s3/repository/PendingUploadRepository.java
+++ b/src/main/java/com/example/speechmate_backend/s3/repository/PendingUploadRepository.java
@@ -1,0 +1,15 @@
+package com.example.speechmate_backend.s3.repository;
+
+import com.example.speechmate_backend.s3.domain.PendingUpload;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PendingUploadRepository extends JpaRepository<PendingUpload, Long> {
+
+    Optional<PendingUpload> findByS3KeyAndUserId(String s3Key, Long userId);
+
+    List<PendingUpload> findByCreatedAtBefore(LocalDateTime cutoff);
+}

--- a/src/main/java/com/example/speechmate_backend/s3/scheduler/PendingUploadCleanupScheduler.java
+++ b/src/main/java/com/example/speechmate_backend/s3/scheduler/PendingUploadCleanupScheduler.java
@@ -1,0 +1,42 @@
+package com.example.speechmate_backend.s3.scheduler;
+
+import com.example.speechmate_backend.s3.domain.PendingUpload;
+import com.example.speechmate_backend.s3.repository.PendingUploadRepository;
+import com.example.speechmate_backend.s3.service.S3UploadPresignedUrlService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PendingUploadCleanupScheduler {
+
+    private final PendingUploadRepository pendingUploadRepository;
+    private final S3UploadPresignedUrlService s3UploadPresignedUrlService;
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void cleanUpStalePendingUploads() {
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
+        List<PendingUpload> stale = pendingUploadRepository.findByCreatedAtBefore(cutoff);
+
+        if (stale.isEmpty()) return;
+
+        stale.forEach(p -> {
+            try {
+                s3UploadPresignedUrlService.deleteObject(p.getS3Key());
+            } catch (Exception e) {
+                log.warn("S3 오브젝트 삭제 실패 (key={}): {}", p.getS3Key(), e.getMessage());
+            }
+        });
+
+        pendingUploadRepository.deleteAll(stale);
+        log.info("만료된 PendingUpload {}건 정리 완료", stale.size());
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/s3/service/S3UploadPresignedUrlService.java
+++ b/src/main/java/com/example/speechmate_backend/s3/service/S3UploadPresignedUrlService.java
@@ -6,6 +6,8 @@ import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.controller.dto.VoiceKeyDto;
+import com.example.speechmate_backend.s3.domain.PendingUpload;
+import com.example.speechmate_backend.s3.repository.PendingUploadRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,7 @@ import java.util.UUID;
 public class S3UploadPresignedUrlService {
 
     private final AmazonS3 amazonS3;
+    private final PendingUploadRepository pendingUploadRepository;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -35,6 +38,9 @@ public class S3UploadPresignedUrlService {
         URL url = amazonS3.generatePresignedUrl(
                 getGeneratePreSignedUrlRequest(bucket, fileName, fileExtension)
         );
+
+        pendingUploadRepository.save(new PendingUpload(fileName, userId));
+
         return VoiceKeyDto.of(url.toString(), fileName);
     }
 
@@ -91,5 +97,8 @@ public class S3UploadPresignedUrlService {
         amazonS3.deleteObject(bucket, key);
     }
 
+    public long getObjectContentLength(String key) {
+        return amazonS3.getObjectMetadata(bucket, key).getContentLength();
+    }
 
 }

--- a/src/main/java/com/example/speechmate_backend/speech/repository/SpeechRepository.java
+++ b/src/main/java/com/example/speechmate_backend/speech/repository/SpeechRepository.java
@@ -1,11 +1,13 @@
 package com.example.speechmate_backend.speech.repository;
 
+import com.example.speechmate_backend.speech.AnalysisStatus;
 import com.example.speechmate_backend.speech.domain.Speech;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SpeechRepository extends JpaRepository<Speech, Long> {
@@ -17,5 +19,7 @@ public interface SpeechRepository extends JpaRepository<Speech, Long> {
 
     @Query("SELECT s FROM Speech s JOIN s.analysisResult ar WHERE s.user.id = :userId AND (:lastId IS NULL OR s.id < :lastId) ORDER BY s.id DESC")
     List<Speech> findAnalyzedSpeeches(@Param("userId") Long userId, @Param("lastId") Long lastSpeechId, Pageable pageable);
+
+    List<Speech> findByNonVerbalStatusAndModifiedAtBefore(AnalysisStatus status, LocalDateTime cutoff);
 
 }

--- a/src/main/java/com/example/speechmate_backend/speech/scheduler/NonVerbalAnalysisTimeoutScheduler.java
+++ b/src/main/java/com/example/speechmate_backend/speech/scheduler/NonVerbalAnalysisTimeoutScheduler.java
@@ -1,0 +1,40 @@
+package com.example.speechmate_backend.speech.scheduler;
+
+import com.example.speechmate_backend.speech.AnalysisStatus;
+import com.example.speechmate_backend.speech.domain.Speech;
+import com.example.speechmate_backend.speech.repository.SpeechRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NonVerbalAnalysisTimeoutScheduler {
+
+    private static final int TIMEOUT_MINUTES = 30;
+
+    private final SpeechRepository speechRepository;
+
+    @Scheduled(cron = "0 */10 * * * *")
+    @Transactional
+    public void detectTimedOutJobs() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(TIMEOUT_MINUTES);
+        List<Speech> timedOut = speechRepository
+                .findByNonVerbalStatusAndModifiedAtBefore(AnalysisStatus.IN_PROGRESS, threshold);
+
+        if (timedOut.isEmpty()) return;
+
+        timedOut.forEach(s -> {
+            log.warn("비언어 분석 타임아웃 (speechId={}, modifiedAt={})", s.getId(), s.getModifiedAt());
+            s.setNonVerbalStatus(AnalysisStatus.FAILED);
+        });
+
+        log.info("IN_PROGRESS 타임아웃 처리 {}건 → FAILED", timedOut.size());
+    }
+}

--- a/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
+++ b/src/main/java/com/example/speechmate_backend/speech/service/SpeechService.java
@@ -3,9 +3,12 @@ package com.example.speechmate_backend.speech.service;
 import com.example.speechmate_backend.common.ApiResponse;
 import com.example.speechmate_backend.common.aop.DistributedLock;
 import com.example.speechmate_backend.common.exception.*;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.example.speechmate_backend.config.redis.RedisUtil;
 import com.example.speechmate_backend.s3.MediaFileExtension;
 import com.example.speechmate_backend.s3.controller.dto.VoiceKeyDto;
+import com.example.speechmate_backend.s3.domain.PendingUpload;
+import com.example.speechmate_backend.s3.repository.PendingUploadRepository;
 import com.example.speechmate_backend.s3.service.S3UploadPresignedUrlService;
 import com.example.speechmate_backend.speech.AnalysisStatus;
 import com.example.speechmate_backend.speech.controller.SortType;
@@ -54,6 +57,7 @@ public class SpeechService {
     private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> redisTemplate;
+    private final PendingUploadRepository pendingUploadRepository;
 
     // Redis Stream에 사용할 작업 큐 이름 (상수)
     private static final String STREAM_KEY = "nonverbal-analysis-jobs";
@@ -328,19 +332,48 @@ public class SpeechService {
         return dto;
     }
 
+    private static final long MAX_FILE_SIZE_BYTES = 500L * 1024 * 1024; // 500MB
+
     @Transactional
     public SpeechS3CallbackDto registerUploadedSpeech(Long userId, String fileKey, Long durationSeconds) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
 
-        Speech speech = new Speech();
-        speech.setFileUrl(fileKey); // 실제 s3 key
+        String ext = fileKey.contains(".")
+                ? fileKey.substring(fileKey.lastIndexOf('.') + 1).toUpperCase()
+                : "";
+        try {
+            MediaFileExtension.valueOf(ext);
+        } catch (IllegalArgumentException e) {
+            throw InvalidFileExtensionException.EXCEPTION;
+        }
 
-        String mediaType = fileKey.toLowerCase().endsWith(".mp4") || fileKey.toLowerCase().endsWith(".mov") ? "VIDEO" : "AUDIO";
+        PendingUpload pending = pendingUploadRepository
+                .findByS3KeyAndUserId(fileKey, userId)
+                .orElseThrow(() -> SpeechFileKeyNotFoundException.EXCEPTION);
+
+        try {
+            long fileSize = s3UploadPresignedUrlService.getObjectContentLength(fileKey);
+            if (fileSize > MAX_FILE_SIZE_BYTES) {
+                s3UploadPresignedUrlService.deleteObject(fileKey);
+                throw FileTooLargeException.EXCEPTION;
+            }
+        } catch (AmazonS3Exception e) {
+            log.error("S3 파일 메타데이터 조회 실패 (key={}): {}", fileKey, e.getMessage());
+            throw SpeechFileKeyNotFoundException.EXCEPTION;
+        }
+
+        Speech speech = new Speech();
+        speech.setFileUrl(fileKey);
+
+        String mediaType = ext.equals("MP4") || ext.equals("MOV") ? "VIDEO" : "AUDIO";
         speech.updateMediaInfo(durationSeconds, mediaType);
 
         user.addSpeech(speech);
         speechRepository.save(speech);
+
+        pendingUploadRepository.delete(pending);
+
         String s3Url = s3UploadPresignedUrlService.getPublicS3Url(speech.getFileUrl());
         return SpeechS3CallbackDto.of(speech.getId(), s3Url);
     }
@@ -610,6 +643,7 @@ public AnalysisResultDto getSpeechContentAnalysisById(Long speechId) {
 
             // Stream에 메시지 추가
             redisTemplate.opsForStream().add(STREAM_KEY, jobData);
+            redisTemplate.opsForStream().trim(STREAM_KEY, MAX_STREAM_LENGTH);
 
             // (참고: MapRecord.create(STREAM_KEY, jobData)를 사용하는 방법도 있습니다)
 


### PR DESCRIPTION
- s3-callback 시 확장자·파일 크기(500MB)·PendingUpload 소유자 검증 추가
- PendingUpload 엔티티/리포지토리 도입 및 24시간 후 orphaned object 정리 스케줄러 추가
- Python 콜백 3회 재시도 + 지수 백오프(5s/15s/45s) 추가
- IN_PROGRESS 30분 타임아웃 시 FAILED 전환 스케줄러 추가
- Redis Stream MAXLEN(10000) trim 적용
- Redis maxmemory 1gb / noeviction 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File upload now validates extensions and enforces 500MB maximum file size
  * Automatic cleanup of abandoned uploads after 24 hours
  * Enhanced callback retry mechanism with improved reliability

* **Bug Fixes**
  * Analysis jobs stuck for over 30 minutes are now automatically detected and marked as failed

* **Chores**
  * Added monitoring for Redis and AI server metrics
  * Improved infrastructure resource management configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->